### PR TITLE
Use CSS system font stack

### DIFF
--- a/components/meta.js
+++ b/components/meta.js
@@ -14,7 +14,7 @@ export default () => (
     </Head>
     <style jsx global>{`
       body {
-        font-family: SF UI Text, -apple-system, Helvetica, Arial, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
         background: #eee;
       }
 


### PR DESCRIPTION
So `SF UI Text` isn't really reliable and shows up as Helvetica in Chrome/OSX:

![pasted_image_1_3_17__10_08_am](https://cloud.githubusercontent.com/assets/74385/21598729/b3902c3e-d19c-11e6-92e2-e3e1e20bfe88.png)

This replaces *SF UI Text* with Medium's solution. https://medium.com/design/system-shock-6b1dc6d6596f